### PR TITLE
Ignore IDE folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 
 *.db
+
+.idea/
+.vscode/


### PR DESCRIPTION
As most people use VS Code or JetBrains solutions, the IDEs' folders should not be added to the repository.